### PR TITLE
feat: Web LLM providers (OpenAI/Anthropic/Gemini) + JSON coercion

### DIFF
--- a/electron/ipc/llm.ts
+++ b/electron/ipc/llm.ts
@@ -34,6 +34,212 @@ interface LLMProvider {
   getModels(): Promise<string[]>;
 }
 
+/* ------------------------------------------------------------------
+   Cloud providers require API keys – read once from process.env.
+-------------------------------------------------------------------*/
+const OPENAI_KEY      = process.env.OPENAI_API_KEY      ?? '';
+const ANTHROPIC_KEY   = process.env.ANTHROPIC_API_KEY   ?? '';
+const GEMINI_KEY      = process.env.GEMINI_API_KEY      ?? '';
+
+/* ------------------------------------------------------------------
+   Shared tiny helper to stream server-sent-events JSON lines.
+-------------------------------------------------------------------*/
+async function* streamSSE(
+  res: Response,
+  guards: ReturnType<typeof createAbortGuards>,
+  extract: (json: any) => string | undefined
+): AsyncGenerator<string, void, unknown> {
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error('No response body');
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    guards.startInactivity();
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const data = line.slice(6).trim();
+      if (data === '[DONE]') return;
+      try {
+        const json = JSON.parse(data);
+        const part = extract(json);
+        if (part) yield part;
+      } catch {
+        /* ignore parse errors */
+      }
+    }
+  }
+}
+
+/* ==================================================================
+   OpenAI (chat/stream)
+===================================================================*/
+class OpenAIProvider implements LLMProvider {
+  name = 'OpenAI';
+  endpoint = 'https://api.openai.com';
+
+  async check(): Promise<boolean> {
+    if (!OPENAI_KEY) return false;
+    try {
+      const r = await fetch(`${this.endpoint}/v1/models`, {
+        headers: { Authorization: `Bearer ${OPENAI_KEY}` }
+      });
+      return r.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async *generate(prompt: string, options: any = {}): AsyncGenerator<string> {
+    const guards = createAbortGuards(options.inactivityMs, options.overallMs, options.abortController);
+    try {
+      const res = await fetch(`${this.endpoint}/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${OPENAI_KEY}`
+        },
+        signal: guards.signal,
+        body: JSON.stringify({
+          model: options.model || 'gpt-3.5-turbo',
+          stream: true,
+          temperature: options.temperature ?? 0.3,
+          max_tokens: options.unbounded ? undefined : options.maxTokens ?? 700,
+          messages: [{ role: 'user', content: prompt }]
+        })
+      });
+      if (!res.ok) throw new Error(`OpenAI error: ${res.status}`);
+
+      for await (const chunk of streamSSE(res, guards, (j) => j.choices?.[0]?.delta?.content)) {
+        yield chunk;
+      }
+    } catch (err: any) {
+      if (err?.name === 'AbortError') throw new Error('LLM stream stalled (no data for 120 s)');
+      throw err;
+    } finally {
+      guards.clear();
+    }
+  }
+
+  async getModels(): Promise<string[]> {
+    if (!OPENAI_KEY) return [];
+    try {
+      const r = await fetch(`${this.endpoint}/v1/models`, {
+        headers: { Authorization: `Bearer ${OPENAI_KEY}` }
+      });
+      const d: any = await r.json();
+      return (d.data ?? []).map((m: any) => m.id).filter((id: string) =>
+        ['gpt-4', 'gpt-4o', 'gpt-3.5'].some(k => id.includes(k))
+      );
+    } catch {
+      return [];
+    }
+  }
+}
+
+/* ==================================================================
+   Anthropic Claude-3
+===================================================================*/
+class AnthropicProvider implements LLMProvider {
+  name = 'Anthropic';
+  endpoint = 'https://api.anthropic.com';
+
+  async check(): Promise<boolean> {
+    return Boolean(ANTHROPIC_KEY); // minimal – full call costs quota
+  }
+
+  async *generate(prompt: string, options: any = {}): AsyncGenerator<string> {
+    const guards = createAbortGuards(options.inactivityMs, options.overallMs, options.abortController);
+    try {
+      const res = await fetch(`${this.endpoint}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'x-api-key': ANTHROPIC_KEY
+        },
+        signal: guards.signal,
+        body: JSON.stringify({
+          model: options.model || 'claude-3-sonnet-20240229',
+          max_tokens: options.unbounded ? 4096 : options.maxTokens ?? 700,
+          temperature: options.temperature ?? 0.3,
+          stream: true,
+          messages: [{ role: 'user', content: prompt }]
+        })
+      });
+      if (!res.ok) throw new Error(`Anthropic error: ${res.status}`);
+
+      for await (const chunk of streamSSE(res, guards, (j) => {
+        if (j.type === 'content_block_delta') return j.delta?.text;
+        if (j.type === 'message_delta') return j.delta?.content?.[0]?.text;
+        return undefined;
+      })) {
+        yield chunk;
+      }
+    } catch (err: any) {
+      if (err?.name === 'AbortError') throw new Error('LLM stream stalled (no data for 120 s)');
+      throw err;
+    } finally {
+      guards.clear();
+    }
+  }
+
+  async getModels(): Promise<string[]> {
+    return [
+      'claude-3-opus-20240229',
+      'claude-3-sonnet-20240229',
+      'claude-3-haiku-20240307'
+    ];
+  }
+}
+
+/* ==================================================================
+   Google Gemini – non-streaming simple call
+===================================================================*/
+class GeminiProvider implements LLMProvider {
+  name = 'Gemini';
+  endpoint = 'https://generativelanguage.googleapis.com/v1beta';
+
+  async check(): Promise<boolean> {
+    return Boolean(GEMINI_KEY);
+  }
+
+  async *generate(prompt: string, options: any = {}): AsyncGenerator<string> {
+    const model = options.model || 'gemini-1.5-flash-latest';
+    const url = `${this.endpoint}/models/${model}:generateContent?key=${GEMINI_KEY}`;
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }]}],
+          generationConfig: {
+            temperature: options.temperature ?? 0.3,
+            maxOutputTokens: options.unbounded ? 2048 : options.maxTokens ?? 700,
+            topP: options.topP ?? 0.9
+          }
+        })
+      });
+      if (!res.ok) throw new Error(`Gemini error: ${res.status}`);
+      const d: any = await res.json();
+      const text = d.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+      if (text) yield text;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async getModels(): Promise<string[]> {
+    return ['gemini-1.5-flash-latest', 'gemini-1.5-pro-latest'];
+  }
+}
+
 class OllamaProvider implements LLMProvider {
   name = 'Ollama';
   endpoint = 'http://localhost:11434';
@@ -243,6 +449,9 @@ class LLMManager {
   constructor() { 
     this.providers.set('ollama', new OllamaProvider()); 
     this.providers.set('lmstudio', new LMStudioProvider()); 
+    this.providers.set('openai', new OpenAIProvider());
+    this.providers.set('anthropic', new AnthropicProvider());
+    this.providers.set('gemini', new GeminiProvider());
   }
 
   public getProviderNames(): string[] {
@@ -284,6 +493,25 @@ class LLMManager {
     if (await lms.check()) { 
       this.active = lms; 
       return { provider: 'lmstudio', models: await lms.getModels() }; 
+    }
+
+    /* -------------------------- Web providers -------------------------- */
+    const openai = this.providers.get('openai')!;
+    if (await openai.check()) {
+      this.active = openai;
+      return { provider: 'openai', models: await openai.getModels() };
+    }
+
+    const anthropic = this.providers.get('anthropic')!;
+    if (await anthropic.check()) {
+      this.active = anthropic;
+      return { provider: 'anthropic', models: await anthropic.getModels() };
+    }
+
+    const gem = this.providers.get('gemini')!;
+    if (await gem.check()) {
+      this.active = gem;
+      return { provider: 'gemini', models: await gem.getModels() };
     }
     
     return null;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,6 +18,33 @@ import { createApplicationMenu } from './utils/menu';
 let mainWindow: BrowserWindow | null = null;
 let dbPath: string;
 
+/* --------------------------------------------------------------
+   Dev-only helper: find a running Vite dev server we can load.
+-------------------------------------------------------------- */
+async function resolveDevServerUrl(): Promise<string> {
+  const candidates = [
+    process.env.VITE_DEV_SERVER_URL,
+    'http://127.0.0.1:3001',
+    'http://127.0.0.1:3000',
+    'http://localhost:3001',
+    'http://localhost:3000',
+  ].filter(Boolean) as string[];
+
+  for (const url of candidates) {
+    try {
+      const controller = new AbortController();
+      const id = setTimeout(() => controller.abort(), 1500);
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(id);
+      if (res.ok) return url;
+    } catch {
+      /* try next candidate */
+    }
+  }
+  // fallback
+  return 'http://127.0.0.1:3000';
+}
+
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
@@ -30,7 +57,7 @@ if (!gotTheLock) {
     }
   });
 
-  app.whenReady().then(() => {
+  app.whenReady().then(async () => {
     const documentsPath = app.getPath('documents');
     const appDataPath = path.join(documentsPath, 'VibeCodeSystem');
     dbPath = path.join(appDataPath, 'database.db');
@@ -56,11 +83,20 @@ if (!gotTheLock) {
     Menu.setApplicationMenu(createApplicationMenu(mainWindow));
 
     if (process.env.NODE_ENV === 'development') {
-      // Prefer IPv4 loopback to avoid IPv6 ↔ IPv4 “connection refused” issues.
-      // Allow overriding via VITE_DEV_SERVER_URL for flexibility (e.g. custom port).
-      const devUrl =
-        process.env.VITE_DEV_SERVER_URL || 'http://127.0.0.1:3000';
-      mainWindow.loadURL(devUrl);
+      // Dynamically locate the running Vite dev server (3001 > 3000 fallback)
+      const devUrl = await resolveDevServerUrl();
+
+      console.log('[electron] NODE_ENV=development');
+      console.log('[electron] using dev server:', devUrl);
+
+      mainWindow.webContents.on('did-fail-load', (_e, code, desc, url) => {
+        console.error('[electron] did-fail-load', { code, desc, url });
+      });
+      mainWindow.webContents.on('did-finish-load', () => {
+        console.log('[electron] did-finish-load', mainWindow?.webContents.getURL());
+      });
+
+      await mainWindow.loadURL(devUrl);
       mainWindow.webContents.openDevTools();
     } else {
       // In production, resolve the renderer HTML relative to the compiled

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,8 +22,12 @@ let dbPath: string;
    Dev-only helper: find a running Vite dev server we can load.
 -------------------------------------------------------------- */
 async function resolveDevServerUrl(): Promise<string> {
+  /* If the caller already provided a dev-server URL, trust it first. */
+  if (process.env.VITE_DEV_SERVER_URL) {
+    return process.env.VITE_DEV_SERVER_URL;
+  }
+
   const candidates = [
-    process.env.VITE_DEV_SERVER_URL,
     'http://127.0.0.1:3001',
     'http://127.0.0.1:3000',
     'http://localhost:3001',
@@ -96,7 +100,21 @@ if (!gotTheLock) {
         console.log('[electron] did-finish-load', mainWindow?.webContents.getURL());
       });
 
-      await mainWindow.loadURL(devUrl);
+      try {
+        await mainWindow.loadURL(devUrl);
+      } catch (e) {
+        console.error('[electron] loadURL error:', e);
+        /* ----------------------------------------------------
+           Dev server unreachable – fall back to production
+           build so the UI still appears.
+        ---------------------------------------------------- */
+        try {
+          console.warn('[electron] Falling back to built index.html');
+          await mainWindow.loadFile(path.join(__dirname, '../build/index.html'));
+        } catch (fallbackErr) {
+          console.error('[electron] Fallback loadFile failed:', fallbackErr);
+        }
+      }
       mainWindow.webContents.openDevTools();
     } else {
       // In production, resolve the renderer HTML relative to the compiled

--- a/src/components/stages/StageShell.tsx
+++ b/src/components/stages/StageShell.tsx
@@ -13,6 +13,7 @@ import {
   validateStageOutput,
   ValidationResult,
 } from '../../utils/validators';
+import { schemaForStage } from '../../utils/schemas';
 
 interface StageShellProps {
   stageId: number;
@@ -130,6 +131,31 @@ ${lastChunk}`;
     }
   }
 
+  /* --------------------------------------------------
+     Helper to coerce arbitrary text -> STRICT JSON
+  -------------------------------------------------- */
+  async function coerceToJson(text: string, budget: number): Promise<string> {
+    const prompt = `You previously produced the following content but it does **not** parse as valid JSON.\n\n---\n${text}\n---\n\nConvert the entire content into STRICT JSON ONLY (no markdown fences, no commentary) that matches the following JSON schema for stage ${stageId}.\n\n${schemaForStage(stageId)}\n\nReturn ONLY the JSON.`;
+
+    try {
+      const result = await (window as any).electronAPI.generateContent(
+        adaptPromptForModel(prompt, llm.selectedModel?.id),
+        {
+          model: llm.selectedModel?.id,
+          temperature: 0.2,
+          maxTokens: budget,
+          unbounded: llm.params.unbounded,
+          inactivityMs: llm.params.inactivityMs,
+          overallMs: llm.params.overallMs,
+        }
+      );
+      return typeof result === 'string' ? result : '';
+    } catch (err) {
+      console.error('Coercion error:', err);
+      return '';
+    }
+  }
+
   /* ------------------------------------------------------------------
      Load content from a past cycle into the current one
   -------------------------------------------------------------------*/
@@ -206,6 +232,15 @@ The output must have at least ${min} items in the mvp_features array.`;
             if (!isIncompleteJson(aggregate)) break; // Stop if we have valid JSON
             
             const continuation = await continueJson(aggregate, 900);
+
+        // If still not valid JSON, try a coercion pass
+        if (isIncompleteJson(aggregate)) {
+          const coerced = await coerceToJson(aggregate, 900);
+          if (coerced) {
+            aggregate = coerced;
+            setOutput(aggregate);
+          }
+        }
             if (!continuation) break; // Stop if continuation failed
             
             aggregate += continuation;
@@ -358,8 +393,16 @@ The output must have at least ${min} items in the mvp_features array.`;
             if (!isIncompleteJson(aggregate)) break; // Stop if we have valid JSON
             
             const continuation = await continueJson(aggregate, continuationBudget);
+
+        // If still not valid JSON, try a coercion pass
+        if (isIncompleteJson(aggregate)) {
+          const coerced = await coerceToJson(aggregate, 900);
+          if (coerced) {
+            aggregate = coerced;
+          }
+        }
             if (!continuation) break; // Stop if continuation failed
-            
+        setOutput(aggregate);
             aggregate += continuation;
             setOutput(aggregate); // Update UI with progress
             
@@ -517,6 +560,15 @@ The output must have at least ${min} items in the mvp_features array.`;
             if (!isIncompleteJson(improvedAggregate)) break; // Stop if we have valid JSON
             
             const continuation = await continueJson(improvedAggregate, continuationBudget);
+
+        // If still not valid JSON, try a coercion pass
+        if (isIncompleteJson(improvedAggregate)) {
+          const coerced = await coerceToJson(improvedAggregate, 900);
+          if (coerced) {
+            improvedAggregate = coerced;
+            setOutput(improvedAggregate);
+          }
+        }
             if (!continuation) break; // Stop if continuation failed
             
             improvedAggregate += continuation;

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -68,7 +68,12 @@ export const useAppStore = create<AppState>((set, get) => ({
   llm: {
     providers: [
       { name: 'ollama',   endpoint: 'http://localhost:11434', isActive: false },
-      { name: 'lmstudio', endpoint: 'http://localhost:1234',  isActive: false }
+      { name: 'lmstudio', endpoint: 'http://localhost:1234',  isActive: false },
+
+      // --- Cloud-based providers (keys expected via env vars / settings) ---
+      { name: 'openai',    endpoint: 'https://api.openai.com',                           isActive: false },
+      { name: 'anthropic', endpoint: 'https://api.anthropic.com',                        isActive: false },
+      { name: 'gemini',    endpoint: 'https://generativelanguage.googleapis.com',        isActive: false }
     ],
     availableModels: [],
     selectedModel: null,


### PR DESCRIPTION
This PR integrates web-based LLM providers and improves JSON output robustness.\n\nHighlights:\n- Add OpenAI, Anthropic Claude, and Gemini providers to Electron IPC LLM manager\n- SSE streaming for OpenAI/Anthropic; simple call for Gemini\n- Update store to surface providers in Header dropdown\n- JSON coercion fallback in StageShell to reduce 'Output is not valid JSON' errors\n\nAll checks:\n- npm ci completed\n- tsc typecheck passed\n- electron build compiled\n\nDroid-assisted